### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,17 +28,19 @@ APPMAR is written in Python 3.7, and it requires a variety of dependencies to ru
 
 **Dependencies:**
 
-- cfgrib
-- gdal
-- wxpython
-- numpy==1.23.3
-- matplotlib==3.2
-- scipy
-- xarray
-- pandas
-- cartopy
-- scikit-learn
-- kneed
+- python=3.8.18
+- cfgrib=0.9.10.1
+- gdal=3.5.1
+- wxpython=4.2.1
+- numpy=1.23.3
+- matplotlib=3.2.2
+- scipy=1.9.1
+- xarray=2022.6.0
+- pandas=1.4.4
+- cartopy=0.20.3
+- scikit-learn=1.1.2
+- kneed=0.7.0
+- findlibs=0.0.5
 
 In order to install and run APPMAR, follow these steps:
 
@@ -47,7 +49,7 @@ In order to install and run APPMAR, follow these steps:
 2. Create a new conda environment for APPMAR and its dependencies:
 
 ```
-conda create -n my-new-env -c conda-forge "python>=3.7" cfgrib gdal wxpython numpy==1.23.3 matplotlib=3.2 scipy xarray pandas cartopy scikit-learn kneed
+conda create -n my-new-env -c conda-forge python=3.8.18 cfgrib=0.9.10.1 gdal=3.5.1 wxpython=4.2.1 numpy=1.23.3 matplotlib=3.2.2 scipy=1.9.1 xarray=2022.6.0 pandas=1.4.4 cartopy=0.20.3 scikit-learn=1.1.2 kneed=0.7.0 findlibs=0.0.5
 ```
 
 3. Activate the new environment:


### PR DESCRIPTION
Hi,

The Appmar installation process is currently experiencing issues during environment resolution for installing dependencies, causing that after 4 hours of waiting, no solution is reached.

After reviewing, I found the latest versions of the dependencies that keep the environment buildable, taking into account a current issue with a dependency of the cfgrib library called findlibs, which last version should not be installable on Python<3.9 and Conda tries to do it. See: https://github.com/ecmwf/findlibs/issues/25

I propose changing the instruction to create the environment from:
`conda create -n my-new-env -c conda-forge "python>=3.7" cfgrib gdal wxpython numpy==1.23.3 matplotlib=3.2 scipy xarray pandas cartopy scikit-learn kneed`

to:
`conda create -n my-new-env -c conda-forge python=3.8.18 cfgrib=0.9.10.1 gdal=3.5.1 wxpython=4.2.1 numpy=1.23.3 matplotlib=3.2.2 scipy=1.9.1 xarray=2022.6.0 pandas=1.4.4 cartopy=0.20.3 scikit-learn=1.1.2 kneed=0.7.0 findlibs=0.0.5`

After this change, Conda resolves the environment in less than a minute and Appmar works properly.